### PR TITLE
카테고리 등록 API 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,12 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("org.springframework.boot") version "2.6.4"
+    id("org.springframework.boot") version "2.5.6"
     id("io.spring.dependency-management") version "1.0.11.RELEASE"
     kotlin("jvm") version "1.6.10"
     kotlin("plugin.spring") version "1.6.10"
     kotlin("plugin.jpa") version "1.6.10"
+    kotlin("kapt") version "1.3.61"
 }
 
 group = "me.hyungil"
@@ -16,7 +17,12 @@ repositories {
     mavenCentral()
 }
 
+sourceSets["main"].withConvention(org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet::class) {
+    kotlin.srcDir("$buildDir/generated/source/kapt/main")
+}
+
 apply(plugin = "kotlin")
+apply(plugin = "kotlin-kapt")
 apply(plugin = "org.springframework.boot")
 apply(plugin = "io.spring.dependency-management")
 apply(plugin = "org.jetbrains.kotlin.plugin.allopen")
@@ -43,6 +49,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
 
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("com.querydsl:querydsl-jpa:4.4.0")
+
+    kapt("com.querydsl:querydsl-apt:4.4.0:jpa")
 
     runtimeOnly ("com.h2database:h2")
 

--- a/src/main/kotlin/me/hyungil/category/category/application/CategoryService.kt
+++ b/src/main/kotlin/me/hyungil/category/category/application/CategoryService.kt
@@ -1,0 +1,49 @@
+package me.hyungil.category.category.application
+
+import me.hyungil.category.category.commom.enumeration.ExceptionType.NOT_FOUND_PARENT_CATEGORY
+import me.hyungil.category.category.commom.exception.PostNotFoundException
+import me.hyungil.category.category.domain.category.Category
+import me.hyungil.category.category.domain.category.CategoryRepository
+import me.hyungil.category.category.presentation.dto.request.CategoryCreateRequest
+import me.hyungil.category.category.presentation.dto.response.GetCategoryResponse
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CategoryService(
+    private val categoryRepository: CategoryRepository
+) {
+    @Transactional
+    fun createCategory(request: CategoryCreateRequest) = when (request.parentCategoryId) {
+        null, 0L -> createRootCategory(request)
+        else -> createSubCategory(request)
+    }
+
+    private fun createSubCategory(request: CategoryCreateRequest): GetCategoryResponse {
+        val parentCategory = findById(request.parentCategoryId)
+        val rootCategory = findByIdWithRootCategory(parentCategory.id)
+
+        val createSubCategory = Category(request.name).apply {
+            updateRootCategory(rootCategory)
+            updateParentCategory(parentCategory)
+        }
+
+        parentCategory.updateSubCategory(createSubCategory)
+
+        return GetCategoryResponse.from(categoryRepository.save(createSubCategory))
+    }
+
+    private fun createRootCategory(request: CategoryCreateRequest): GetCategoryResponse {
+        val createRootCategory = Category(request.name)
+
+        return GetCategoryResponse.from(categoryRepository.save(createRootCategory).apply { updateRootCategory(this) })
+    }
+
+    private fun findById(id: Long?): Category =
+        categoryRepository.findByIdOrNull(id) ?: throw PostNotFoundException(NOT_FOUND_PARENT_CATEGORY.message)
+
+    private fun findByIdWithRootCategory(id: Long) =
+        categoryRepository.findByIdWithRootCategory(id)
+            ?: throw PostNotFoundException(NOT_FOUND_PARENT_CATEGORY.message)
+}

--- a/src/main/kotlin/me/hyungil/category/category/commom/enumeration/ExceptionType.kt
+++ b/src/main/kotlin/me/hyungil/category/category/commom/enumeration/ExceptionType.kt
@@ -1,0 +1,8 @@
+package me.hyungil.category.category.commom.enumeration
+
+enum class ExceptionType(
+    val message: String
+) {
+    NOT_FOUND_PARENT_CATEGORY("부모 카테고리가 존재하지 않습니다."),
+    NOT_FOUND_ROOT_CATEGORY("루트 카테고리가 존재하지 않습니다.")
+}

--- a/src/main/kotlin/me/hyungil/category/category/commom/exception/PostNotFoundException.kt
+++ b/src/main/kotlin/me/hyungil/category/category/commom/exception/PostNotFoundException.kt
@@ -1,0 +1,5 @@
+package me.hyungil.category.category.commom.exception
+
+class PostNotFoundException(message: String) : RuntimeException(message) {
+    constructor() : this("존재하지 않는 리소스입니다.")
+}

--- a/src/main/kotlin/me/hyungil/category/category/config/QuerydslConfig.kt
+++ b/src/main/kotlin/me/hyungil/category/category/config/QuerydslConfig.kt
@@ -1,0 +1,16 @@
+package me.hyungil.category.category.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+@Configuration
+class QuerydslConfig(
+    @PersistenceContext
+    private val entityManager: EntityManager
+) {
+    @Bean
+    fun jpaQueryFactory() = JPAQueryFactory(this.entityManager)
+}

--- a/src/main/kotlin/me/hyungil/category/category/domain/BaseTimeEntity.kt
+++ b/src/main/kotlin/me/hyungil/category/category/domain/BaseTimeEntity.kt
@@ -1,0 +1,20 @@
+package me.hyungil.category.category.domain
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+import javax.persistence.EntityListeners
+import javax.persistence.MappedSuperclass
+
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseTimeEntity {
+
+    @CreatedDate
+    val createdDate: LocalDateTime = LocalDateTime.now()
+
+    @LastModifiedDate
+    lateinit var modifiedDate: LocalDateTime
+}

--- a/src/main/kotlin/me/hyungil/category/category/domain/category/Category.kt
+++ b/src/main/kotlin/me/hyungil/category/category/domain/category/Category.kt
@@ -1,0 +1,35 @@
+package me.hyungil.category.category.domain.category
+
+import me.hyungil.category.category.domain.BaseTimeEntity
+import me.hyungil.category.category.domain.hierachy.Hierarchy
+import javax.persistence.*
+
+@Entity
+class Category(
+    @Column(nullable = false)
+    val name: String,
+
+    @Embedded
+    val hierarchy: Hierarchy = Hierarchy(),
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_id")
+    val id: Long = 0L
+
+) : BaseTimeEntity() {
+
+    fun updateRootCategory(rootCategory: Category) {
+        hierarchy.updateRootCategory(rootCategory)
+    }
+
+    fun updateParentCategory(parentCategory: Category) {
+        hierarchy.updateParentCategory(parentCategory)
+    }
+
+    fun updateSubCategory(subCategory: Category) {
+        hierarchy.updateUpdateSubCategory(subCategory)
+    }
+
+    fun getDepth() = hierarchy.getDepth()
+}

--- a/src/main/kotlin/me/hyungil/category/category/domain/category/CategoryRepository.kt
+++ b/src/main/kotlin/me/hyungil/category/category/domain/category/CategoryRepository.kt
@@ -1,0 +1,5 @@
+package me.hyungil.category.category.domain.category
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CategoryRepository : JpaRepository<Category, Long>, CustomCategoryRepository

--- a/src/main/kotlin/me/hyungil/category/category/domain/category/CustomCategoryRepository.kt
+++ b/src/main/kotlin/me/hyungil/category/category/domain/category/CustomCategoryRepository.kt
@@ -1,0 +1,6 @@
+package me.hyungil.category.category.domain.category
+
+interface CustomCategoryRepository {
+
+    fun findByIdWithRootCategory(id: Long): Category?
+}

--- a/src/main/kotlin/me/hyungil/category/category/domain/category/CustomCategoryRepositoryImpl.kt
+++ b/src/main/kotlin/me/hyungil/category/category/domain/category/CustomCategoryRepositoryImpl.kt
@@ -1,0 +1,18 @@
+package me.hyungil.category.category.domain.category
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import me.hyungil.category.category.domain.category.QCategory.category
+import org.springframework.stereotype.Repository
+
+@Repository
+class CustomCategoryRepositoryImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+) : CustomCategoryRepository {
+
+    override fun findByIdWithRootCategory(id: Long): Category? =
+        jpaQueryFactory.selectFrom(category)
+        .innerJoin(category.hierarchy.rootCategory)
+        .fetchJoin()
+        .where(category.id.eq(id))
+        .fetchOne()
+}

--- a/src/main/kotlin/me/hyungil/category/category/domain/hierachy/Hierarchy.kt
+++ b/src/main/kotlin/me/hyungil/category/category/domain/hierachy/Hierarchy.kt
@@ -1,0 +1,42 @@
+package me.hyungil.category.category.domain.hierachy
+
+import me.hyungil.category.category.domain.category.Category
+import javax.persistence.*
+
+@Embeddable
+class Hierarchy {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "root_category_id")
+    private lateinit var rootCategory: Category
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_category_id")
+    private lateinit var parentCategory: Category
+
+    @Column(nullable = false)
+    private var leftNode: Int = 1
+
+    @Column(nullable = false)
+    private var rightNode: Int = 2
+
+    @Column(nullable = false)
+    private var depth: Int = 1
+
+    fun updateUpdateSubCategory(subCategory: Category) {
+        subCategory.hierarchy.rootCategory = this.rootCategory
+        subCategory.hierarchy.depth += 1
+        subCategory.hierarchy.leftNode = this.rightNode
+        subCategory.hierarchy.rightNode += 1
+    }
+
+    fun updateRootCategory(rootCategory: Category) {
+        this.rootCategory = rootCategory
+    }
+
+    fun updateParentCategory(parentCategory: Category) {
+        this.parentCategory = parentCategory
+    }
+
+    fun getDepth() = depth
+}

--- a/src/main/kotlin/me/hyungil/category/category/presentation/CategoryRestController.kt
+++ b/src/main/kotlin/me/hyungil/category/category/presentation/CategoryRestController.kt
@@ -1,0 +1,17 @@
+package me.hyungil.category.category.presentation
+
+import me.hyungil.category.category.application.CategoryService
+import me.hyungil.category.category.presentation.dto.request.CategoryCreateRequest
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+import javax.validation.Valid
+
+@RestController
+@RequestMapping("api/v1/categories")
+class CategoryRestController(
+    private val categoryService: CategoryService
+) {
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createCategory(@RequestBody @Valid request: CategoryCreateRequest) = categoryService.createCategory(request)
+}

--- a/src/main/kotlin/me/hyungil/category/category/presentation/GlobalExceptionRestController.kt
+++ b/src/main/kotlin/me/hyungil/category/category/presentation/GlobalExceptionRestController.kt
@@ -1,0 +1,31 @@
+package me.hyungil.category.category.presentation
+
+import me.hyungil.category.category.commom.exception.PostNotFoundException
+import me.hyungil.category.category.presentation.dto.ErrorResponse
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionRestController {
+
+    companion object {
+        private val logger: Logger = LogManager.getLogger(this)
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleMethodArgumentNotValidException(exception: MethodArgumentNotValidException): ErrorResponse? {
+        val message = exception.bindingResult.fieldError!!.defaultMessage
+        return message?.let { ErrorResponse.of(it) }.also { logger.debug(exception.message, exception) }
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(PostNotFoundException::class)
+    fun handlePostNotFoundException(exception: PostNotFoundException) =
+        exception.message?.let { ErrorResponse.of(it) }.also { logger.debug(exception.message, exception) }
+}

--- a/src/main/kotlin/me/hyungil/category/category/presentation/dto/ErrorResponse.kt
+++ b/src/main/kotlin/me/hyungil/category/category/presentation/dto/ErrorResponse.kt
@@ -1,0 +1,8 @@
+package me.hyungil.category.category.presentation.dto
+
+data class ErrorResponse(val message: String) {
+
+    companion object {
+        fun of(message: String) = ErrorResponse(message)
+    }
+}

--- a/src/main/kotlin/me/hyungil/category/category/presentation/dto/request/CategoryCreateRequest.kt
+++ b/src/main/kotlin/me/hyungil/category/category/presentation/dto/request/CategoryCreateRequest.kt
@@ -1,0 +1,11 @@
+package me.hyungil.category.category.presentation.dto.request
+
+import javax.validation.constraints.NotBlank
+
+data class CategoryCreateRequest(
+
+    val parentCategoryId: Long?,
+
+    @field:NotBlank(message = "잘못된 정보를 입력하셨습니다.")
+    val name: String
+)

--- a/src/main/kotlin/me/hyungil/category/category/presentation/dto/response/GetCategoryResponse.kt
+++ b/src/main/kotlin/me/hyungil/category/category/presentation/dto/response/GetCategoryResponse.kt
@@ -1,0 +1,19 @@
+package me.hyungil.category.category.presentation.dto.response
+
+import me.hyungil.category.category.domain.category.Category
+import java.time.LocalDateTime
+
+data class GetCategoryResponse(
+
+    val categoryId: Long,
+
+    val name: String,
+
+    val depth: Int,
+
+    val createDate: LocalDateTime
+) {
+    companion object {
+        fun from(category: Category) = GetCategoryResponse(category.id, category.name, category.getDepth(), category.createdDate)
+    }
+}


### PR DESCRIPTION
<!--- The issue this PR addresses (이 PR이 다루는 문제) -->
Fixes #3

<!--- Detailed description of the change/feature (변경 / 기능에 대한 자세한 설명) -->
### 상세 내용
카테고리 등록 API 

중첩 세트 모델(The Nested Set Model)로 설계
<img width="731" alt="스크린샷 2022-03-05 오후 10 27 58" src="https://user-images.githubusercontent.com/43127088/156885085-5e703e34-bd4c-471f-ac95-75a91f764e08.png">

카테고리의 depth가 깊어지면 호출하는 쿼리도 복잡해지는 걸 우려해서, `category_id`, `depth`, `parent_category_id`, `root_category`, `left_node`, `right_node`, `created_date`, `modified_date` 컬럼 생성

깊어지는 category depth에 영향 받지 않고 간단하고 빠른 성능의 쿼리를 호출하기 위해 root_category_id와 각 계층에 속해있는 카테고리의 depth, left_node value, right_node value을 이용하여 정렬